### PR TITLE
Install rtpbroadcast cluster in VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,10 +9,8 @@ Vagrant.configure('2') do |config|
   config.landrush.tld = 'dev.cargomedia.ch'
 
   config.vm.define 'cluster', autostart: true do |config|
-    config.vm.box = 'cargomedia/debian-8-amd64-plain'
+    config.vm.box = 'cargomedia/debian-8-amd64-default'
     config.vm.hostname = 'janus-cluster.dev.cargomedia.ch'
-
-    config.vm.network :forwarded_port, guest: 22, host: 22120, id: 'ssh'
     config.vm.network :private_network, ip: '10.10.30.10'
 
     config.vm.provision :puppet do |puppet|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.define 'cluster', autostart: true do |config|
     config.vm.box = 'cargomedia/debian-8-amd64-default'
-    config.vm.hostname = 'janus-cluster.dev.cargomedia.ch'
+    config.vm.hostname = 'janus-test-partition.dev.cargomedia.ch'
     config.vm.network :private_network, ip: '10.10.30.10'
 
     config.vm.provision :puppet do |puppet|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,8 +18,8 @@ Vagrant.configure('2') do |config|
       puppet.environment = 'development'
       puppet.module_path = ['puppet/modules']
       puppet.manifests_path = 'puppet/environments/development/manifests'
-      puppet.hiera_config_path = "puppet/environments/development/hiera/hiera.yaml"
-      puppet.working_directory = "/tmp/vagrant-puppet"
+      puppet.hiera_config_path = 'puppet/environments/development/hiera/hiera.yaml'
+      puppet.working_directory = '/tmp/vagrant-puppet'
       puppet.manifest_file = 'cluster.pp'
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,9 @@
 Vagrant.configure('2') do |config|
   config.ssh.forward_agent = true
 
-  #config.librarian_puppet.puppetfile_dir = 'puppet'
-  #config.librarian_puppet.placeholder_filename = '.gitkeep'
-  #config.librarian_puppet.resolve_options = { :force => false }
+  config.librarian_puppet.puppetfile_dir = 'puppet'
+  config.librarian_puppet.placeholder_filename = '.gitkeep'
+  config.librarian_puppet.resolve_options = { :force => true }
 
   config.landrush.enable
   config.landrush.tld = 'dev.cargomedia.ch'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,28 @@
+Vagrant.configure('2') do |config|
+  config.ssh.forward_agent = true
+
+  #config.librarian_puppet.puppetfile_dir = 'puppet'
+  #config.librarian_puppet.placeholder_filename = '.gitkeep'
+  #config.librarian_puppet.resolve_options = { :force => false }
+
+  config.landrush.enable
+  config.landrush.tld = 'dev.cargomedia.ch'
+
+  config.vm.define 'cluster', autostart: true do |config|
+    config.vm.box = 'cargomedia/debian-8-amd64-plain'
+    config.vm.hostname = 'janus-cluster.dev.cargomedia.ch'
+
+    config.vm.network :forwarded_port, guest: 22, host: 22120, id: 'ssh'
+    config.vm.network :private_network, ip: '10.10.30.10'
+
+    config.vm.provision :puppet do |puppet|
+      puppet.environment_path = 'puppet/environments'
+      puppet.environment = 'development'
+      puppet.module_path = ['puppet/modules']
+      puppet.manifests_path = 'puppet/environments/development/manifests'
+      puppet.hiera_config_path = "puppet/environments/development/hiera/hiera.yaml"
+      puppet.working_directory = "/tmp/vagrant-puppet"
+      puppet.manifest_file = 'cluster.pp'
+    end
+  end
+end

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -1,11 +1,3 @@
-mod 'cargomedia/janus',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
-  :path => 'modules/janus'
-
-mod 'cargomedia/janus_cluster_manager',
-  :git => 'git@github.com:cargomedia/puppet-packages.git',
-  :path => 'modules/janus_cluster_manager'
-
 mod 'cargomedia/janus_cluster',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/janus_cluster'

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -1,0 +1,11 @@
+mod 'cargomedia/janus',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/janus'
+
+mod 'cargomedia/janus_cluster_manager',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/janus_cluster_manager'
+
+#mod 'cargomedia/janus_cluster',
+#  :git => 'git@github.com:cargomedia/puppet-cargomedia.git',
+#  :path => 'modules/janus_cluster'

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -6,6 +6,6 @@ mod 'cargomedia/janus_cluster_manager',
   :git => 'git@github.com:cargomedia/puppet-packages.git',
   :path => 'modules/janus_cluster_manager'
 
-#mod 'cargomedia/janus_cluster',
-#  :git => 'git@github.com:cargomedia/puppet-cargomedia.git',
-#  :path => 'modules/janus_cluster'
+mod 'cargomedia/janus_cluster',
+  :git => 'git@github.com:cargomedia/puppet-packages.git',
+  :path => 'modules/janus_cluster'

--- a/puppet/environments/development/hiera/data/defaults.json
+++ b/puppet/environments/development/hiera/data/defaults.json
@@ -10,13 +10,13 @@
   "janus_cluster::partitions": {
     "space-moon1": {
       "manager": {
-        "cluster_manager_url": "http://example.com"
+        "cluster_manager_url": "http://janus-test-partition.dev.cargomedia.ch:8888"
       },
       "members": {
         "origin1": {
           "type": "origin",
           "params": {
-            "hostname": "localhost",
+            "hostname": "janus-test-partition.dev.cargomedia.ch",
             "recording_enabled": true
           }
         },
@@ -24,14 +24,14 @@
           "type": "repeater",
           "upstream": "origin1",
           "params": {
-            "hostname": "localhost"
+            "hostname": "janus-test-partition.dev.cargomedia.ch"
           }
         },
         "repeater2": {
           "type": "repeater",
           "upstream": "repeater1",
           "params": {
-            "hostname": "localhost",
+            "hostname": "janus-test-partition.dev.cargomedia.ch",
             "ws_port": 8200,
             "http_port": 8210
           }
@@ -41,7 +41,7 @@
           "upstream": "repeater2",
           "count": 10,
           "params": {
-            "hostname": "localhost"
+            "hostname": "janus-test-partition.dev.cargomedia.ch"
           }
         }
       },

--- a/puppet/environments/development/hiera/data/defaults.json
+++ b/puppet/environments/development/hiera/data/defaults.json
@@ -3,7 +3,8 @@
   "janus_cluster::node::members": [
     "origin1",
     "repeater1",
-    "repeater1-multiedge"
+    "repeater2",
+    "repeater2-multiedge"
   ],
 
   "janus_cluster::partitions": {
@@ -26,9 +27,18 @@
             "hostname": "localhost"
           }
         },
-        "repeater1-multiedge": {
-          "type": "multi-edge",
+        "repeater2": {
+          "type": "repeater",
           "upstream": "repeater1",
+          "params": {
+            "hostname": "localhost",
+            "ws_port": 8200,
+            "http_port": 8210
+          }
+        },
+        "repeater2-multiedge": {
+          "type": "multi-edge",
+          "upstream": "repeater2",
           "count": 10,
           "params": {
             "hostname": "localhost"
@@ -40,8 +50,8 @@
         "http_port": 8010
       },
       "repeater-defaults": {
-        "ws_port": 9000,
-        "http_port": 9010
+        "ws_port": 8100,
+        "http_port": 8110
       },
       "edge-defaults": {
         "http_port": 10500,

--- a/puppet/environments/development/hiera/data/defaults.json
+++ b/puppet/environments/development/hiera/data/defaults.json
@@ -1,0 +1,56 @@
+{
+  "janus_cluster::node::partition": "space-moon1",
+  "janus_cluster::node::members": [
+    "origin1",
+    "repeater1",
+    "repeater1-multiedge"
+  ],
+
+  "janus_cluster::partitions": {
+    "space-moon1": {
+      "manager": {
+        "cluster_manager_url": "http://example.com"
+      },
+      "members": {
+        "origin1": {
+          "type": "origin",
+          "params": {
+            "hostname": "localhost",
+            "recording_enabled": true
+          }
+        },
+        "repeater1": {
+          "type": "repeater",
+          "upstream": "origin1",
+          "params": {
+            "hostname": "localhost"
+          }
+        },
+        "repeater1-multiedge": {
+          "type": "multi-edge",
+          "upstream": "repeater1",
+          "count": 10,
+          "params": {
+            "hostname": "localhost"
+          }
+        }
+      },
+      "origin-defaults": {
+        "ws_port": 8000,
+        "http_port": 8010
+      },
+      "repeater-defaults": {
+        "ws_port": 9000,
+        "http_port": 9010
+      },
+      "edge-defaults": {
+        "http_port": 10500,
+        "ws_port": 10710,
+        "rtp_port_range_min": 30000,
+        "rtp_port_range_max": 50000,
+        "rtpb_minport": 15000,
+        "rtpb_maxport": 25000
+      }
+    }
+  }
+}

--- a/puppet/environments/development/hiera/data/defaults.json
+++ b/puppet/environments/development/hiera/data/defaults.json
@@ -37,7 +37,7 @@
           }
         },
         "repeater2-multiedge": {
-          "type": "multi-edge",
+          "type": "multiedge",
           "upstream": "repeater2",
           "count": 10,
           "params": {

--- a/puppet/environments/development/hiera/hiera.yaml
+++ b/puppet/environments/development/hiera/hiera.yaml
@@ -1,0 +1,11 @@
+---
+:backends:
+  - json
+
+:hierarchy:
+  - defaults
+
+:json:
+  :datadir: /tmp/vagrant-puppet/environments/development/hiera/data
+
+:merge_behavior: deeper

--- a/puppet/environments/development/manifests/cluster.pp
+++ b/puppet/environments/development/manifests/cluster.pp
@@ -1,0 +1,3 @@
+node default {
+  class { 'janus_cluster::node': }
+}


### PR DESCRIPTION
Part of cargomedia/puppet-cargomedia#1080
After https://github.com/cargomedia/sk/issues/2991

To test https://github.com/cargomedia/janus-cluster-manager

Split rtpbroadcast instance into:
- janus-rtpbroadcast-origin
- janus-rtpbroadcast-repeater
- janus-rtpbroadcast-edge

And install cluster-manager.

cc @tomaszdurka @vogdb @kris-lab 

=== Update @ppp0

use role standalone 3x